### PR TITLE
fix split version to first 3 elements

### DIFF
--- a/python/lib/playonlinux.py
+++ b/python/lib/playonlinux.py
@@ -278,11 +278,11 @@ def VersionLower(version1, version2):
         else:
             return False
 
-    version1 = [ int(digit) for digit in version1[0].split(".") ]
+    version1 = [ int(digit) for digit in version1[0].split(".")[:3] ]
     while len(version1) < 3:
         version1.append(0)
 
-    version2 = [ int(digit) for digit in version2[0].split(".") ]
+    version2 = [ int(digit) for digit in version2[0].split(".")[:3] ]
     while len(version2) < 3:
         version2.append(0)
 


### PR DESCRIPTION
ValueError: invalid literal for int() with base 10: 'post2'

Versions can contain not only digits (for example wx releases: 4.0.7, 4.0.7.post1, 4.0.7.post2, 4.1.0)